### PR TITLE
Update to use portus API 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,428 @@
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ccp_copa"
+version = "0.1.1"
+dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "portus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "isatty"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "portus"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slog-async"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "term"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+"checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+"checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum portus 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8b3cd75dee22c35457f117ccd00dd5330a80999443bc6ec1e88cf8ab8d569c6f"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
+"checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
+"checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
+"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ffb549f212c31e19f3667c55a7f515b983a84aef10fd0a4d1f9c125425115f3"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "ccp_copa"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Venkat Arun <venkatar@mit.edu>"]
 
 [dependencies]
-clap="2.29"
+clap = "2.29"
+fnv = "1"
+portus = "^0.4.1"
 slog = "2"
-slog-term = "2"
 slog-async = "2"
-time="0.1"
-portus = { git = "https://github.com/ccp-project/portus" }
+slog-term = "2"
+time = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,20 @@
 extern crate clap;
+extern crate fnv;
+use fnv::FnvHashMap;
 
 #[macro_use]
 extern crate slog;
 extern crate portus;
 
-use portus::{CongAlg, Config, Datapath, DatapathInfo, DatapathTrait, Report};
 use portus::ipc::Ipc;
 use portus::lang::Scope;
+use portus::{CongAlg, Datapath, DatapathInfo, DatapathTrait, Report};
 
-mod rtt_window;
 mod delta_manager;
-use rtt_window::RTTWindow;
-use delta_manager::{DeltaManager, DeltaMode};
+mod rtt_window;
 pub use delta_manager::DeltaModeConf;
+use delta_manager::{DeltaManager, DeltaMode};
+use rtt_window::RTTWindow;
 mod agg_measurement;
 use agg_measurement::{AggMeasurement, ReportStatus};
 
@@ -36,19 +38,10 @@ pub struct Copa<T: Ipc> {
 
 #[derive(Clone)]
 pub struct CopaConfig {
+    pub logger: Option<slog::Logger>,
     pub init_cwnd: u32,
     pub default_delta: f32,
     pub delta_mode: DeltaModeConf,
-}
-
-impl Default for CopaConfig {
-    fn default() -> Self {
-        CopaConfig {
-            init_cwnd: 0,
-            default_delta: 0.5,
-            delta_mode: DeltaModeConf::Auto,
-        }
-    }
 }
 
 impl<T: Ipc> Copa<T> {
@@ -57,88 +50,52 @@ impl<T: Ipc> Copa<T> {
     }
 
     fn update(&self) {
-        self.control_channel.update_field(
-            &self.sc, 
-            &[("Cwnd", self.cwnd), ("Rate", self.compute_rate())],
-        ).unwrap()
-    }
-
-    fn install(&self) -> Scope {
-        self.control_channel.install(
-            b"
-                (def
-                    (Report 
-                        (volatile acked 0)
-                        (volatile sacked 0) 
-                        (volatile loss 0)
-                        (volatile inflight 0)
-                        (volatile timeout 0)
-                        (volatile rtt 0)
-                        (volatile now 0)
-                        (volatile minrtt +infinity)
-                   )
-                    (basertt +infinity)
-                )
-                (when true
-                    (:= Report.acked (+ Report.acked Ack.bytes_acked))
-                    (:= Report.inflight Flow.packets_in_flight)
-                    (:= Report.rtt Flow.rtt_sample_us)
-                    (:= Report.minrtt (min Report.minrtt Flow.rtt_sample_us))
-                    (:= basertt (min basertt Flow.rtt_sample_us))
-                    (:= Report.sacked (+ Report.sacked Ack.packets_misordered))
-                    (:= Report.loss Ack.lost_pkts_sample)
-                    (:= Report.timeout Flow.was_timeout)
-                    (:= Report.now Ack.now)
-                    (fallthrough)
-                )
-                (when (|| Flow.was_timeout (> Report.loss 0))
-                    (:= Micros 0)
-                    (report)
-                )
-                (when (> Micros (/ basertt 2))
-                    (:= Micros 0)
-                    (report)
-                )
-            ", None,
-        ).unwrap()
+        self.control_channel
+            .update_field(
+                &self.sc,
+                &[("Cwnd", self.cwnd), ("Rate", self.compute_rate())],
+            )
+            .unwrap()
     }
 
     fn delay_control(&mut self, rtt: u32, actual_acked: u32, now: u64) {
-        let increase = rtt as u64 * 1460u64 > (((rtt - self.rtt_win.get_base_rtt()) as f64) * self.delta_manager.get_delta() as f64 * self.cwnd as f64) as u64;
+        let increase = rtt as u64 * 1460u64
+            > (((rtt - self.rtt_win.get_base_rtt()) as f64)
+                * self.delta_manager.get_delta() as f64
+                * self.cwnd as f64) as u64;
 
         let mut acked = actual_acked;
         // Just in case. Sometimes CCP returns after significantly longer than
         // what was asked for. In that case, actual_acked can be huge
         if actual_acked > self.cwnd {
-	          acked = self.cwnd;
+            acked = self.cwnd;
         }
         // Update velocity
         if increase {
             self.cur_direction += 1;
-        }
-        else {
+        } else {
             self.cur_direction -= 1;
         }
 
-        if self.velocity > 1 && ((increase && self.prev_direction < 0) ||
-                            (!increase && self.prev_direction > 0)) {
+        if self.velocity > 1
+            && ((increase && self.prev_direction < 0) || (!increase && self.prev_direction > 0))
+        {
             self.velocity = 1;
             self.time_since_direction = now;
         }
 
-        if now - self.prev_update_rtt >= 2*rtt as u64 && !self.slow_start {
+        if now - self.prev_update_rtt >= 2 * rtt as u64 && !self.slow_start {
             // TODO(venkatar): Time (now) may be a u32 internally, which means it
             // will wrap around. Handle this.
             if (self.prev_direction > 0 && self.cur_direction > 0)
-                || (self.prev_direction < 0 && self.cur_direction < 0) {
-                    if (now - self.time_since_direction) as u32 > 3*rtt {
-                        self.velocity *= 2;
-                    }
-                    else {
-                        assert!(self.velocity == 1);
-                    }
-            }
-            else {
+                || (self.prev_direction < 0 && self.cur_direction < 0)
+            {
+                if (now - self.time_since_direction) as u32 > 3 * rtt {
+                    self.velocity *= 2;
+                } else {
+                    assert!(self.velocity == 1);
+                }
+            } else {
                 self.velocity = 1;
                 self.time_since_direction = now;
             }
@@ -154,39 +111,34 @@ impl<T: Ipc> Copa<T> {
         if self.slow_start {
             if increase {
                 self.cwnd += acked;
-            }
-            else {
+            } else {
                 self.slow_start = false;
             }
-        }
-        else {
+        } else {
             let mut velocity = 1u64;
-            if (increase && self.prev_direction > 0) ||
-                (!increase && self.prev_direction < 0) {
+            if (increase && self.prev_direction > 0) || (!increase && self.prev_direction < 0) {
                 velocity = self.velocity as u64;
             }
 
             // If we are in TCP mode, delta changes with time. Account for that.
-            let delta = match !increase &&
-                self.delta_manager.get_mode() == DeltaMode::TCPCoop {
+            let delta = match !increase && self.delta_manager.get_mode() == DeltaMode::TCPCoop {
                 false => self.delta_manager.get_delta(),
-                true => 1. / (1. + 1. / self.delta_manager.get_delta())
+                true => 1. / (1. + 1. / self.delta_manager.get_delta()),
             };
 
             // Do computations in u64 to avoid overflow. Multiply first so
             // integer division doesn't cause as many problems
-            let change = (velocity * 1448 * (acked as u64) / (self.cwnd as f32 * delta) as u64) as u32;
+            let change =
+                (velocity * 1448 * (acked as u64) / (self.cwnd as f32 * delta) as u64) as u32;
 
             if increase {
                 self.cwnd += change;
-            }
-            else {
+            } else {
                 if change + self.init_cwnd > self.cwnd {
                     self.cwnd = self.init_cwnd;
                     self.velocity = 1;
                     self.time_since_direction = now;
-                }
-                else {
+                } else {
                     self.cwnd -= change;
                 }
             }
@@ -206,21 +158,63 @@ impl<T: Ipc> Copa<T> {
     }
 }
 
-impl<T: Ipc> CongAlg<T> for Copa<T> {
-    type Config = CopaConfig;
+impl<T: Ipc> CongAlg<T> for CopaConfig {
+    type Flow = Copa<T>;
 
-    fn name() -> String {
-        String::from("copa")
+    fn name() -> &'static str {
+        "copa"
     }
 
-    fn create(control: Datapath<T>, cfg: Config<T, Copa<T>>, info: DatapathInfo) -> Self {
-        let mut s = Self {
+    fn datapath_programs(&self) -> FnvHashMap<&'static str, String> {
+        vec![(
+            "copa",
+            "(def
+                (Report 
+                    (volatile acked 0)
+                    (volatile sacked 0) 
+                    (volatile loss 0)
+                    (volatile inflight 0)
+                    (volatile timeout 0)
+                    (volatile rtt 0)
+                    (volatile now 0)
+                    (volatile minrtt +infinity)
+               )
+                (basertt +infinity)
+            )
+            (when true
+                (:= Report.acked (+ Report.acked Ack.bytes_acked))
+                (:= Report.inflight Flow.packets_in_flight)
+                (:= Report.rtt Flow.rtt_sample_us)
+                (:= Report.minrtt (min Report.minrtt Flow.rtt_sample_us))
+                (:= basertt (min basertt Flow.rtt_sample_us))
+                (:= Report.sacked (+ Report.sacked Ack.packets_misordered))
+                (:= Report.loss Ack.lost_pkts_sample)
+                (:= Report.timeout Flow.was_timeout)
+                (:= Report.now Ack.now)
+                (fallthrough)
+            )
+            (when (|| Flow.was_timeout (> Report.loss 0))
+                (:= Micros 0)
+                (report)
+            )
+            (when (> Micros (/ basertt 2))
+                (:= Micros 0)
+                (report)
+            )"
+            .to_string(),
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    fn new_flow(&self, control: Datapath<T>, info: DatapathInfo) -> Self::Flow {
+        let mut s = Copa {
             control_channel: control,
-            logger: cfg.logger,
+            logger: self.logger.clone(),
             cwnd: info.init_cwnd,
             init_cwnd: info.init_cwnd,
             sc: Default::default(),
-            delta_manager: DeltaManager::new(cfg.config.default_delta, cfg.config.delta_mode),
+            delta_manager: DeltaManager::new(self.default_delta, self.delta_mode.clone()),
             slow_start: true,
             rtt_win: RTTWindow::new(),
             velocity: 1,
@@ -232,52 +226,45 @@ impl<T: Ipc> CongAlg<T> for Copa<T> {
             prev_report_time: 0,
         };
 
-        if cfg.config.init_cwnd != 0 {
-            s.cwnd = cfg.config.init_cwnd;
-            s.init_cwnd = cfg.config.init_cwnd;
+        if self.init_cwnd != 0 {
+            s.cwnd = self.init_cwnd;
+            s.init_cwnd = self.init_cwnd;
         }
 
-        s.logger.as_ref().map(|log| {
+        self.logger.as_ref().map(|log| {
             info!(log, "starting copa flow"; "sock_id" => info.sock_id);
         });
 
-        s.sc = s.install();
+        s.sc = s.control_channel.set_program("copa", None).unwrap();
         s.update();
         s
     }
+}
 
+impl<T: Ipc> portus::Flow for Copa<T> {
     fn on_report(&mut self, _sock_id: u32, m: Report) {
-        let (
-            report_status, 
-            was_timeout, 
-            acked, 
-            sacked, 
-            loss, 
-            inflight, 
-            rtt,
-            min_rtt, 
-            now,
-        ) = self.agg_measurement.report(m, &self.sc);
+        let (report_status, was_timeout, acked, sacked, loss, _inflight, _rtt, min_rtt, now) =
+            self.agg_measurement.report(m, &self.sc);
         if report_status == ReportStatus::UrgentReport {
             if was_timeout {
                 self.handle_timeout();
             }
 
-            self.delta_manager.report_measurement(&mut self.rtt_win,
-                                                  0, loss, now);
-        }
-        else if report_status == ReportStatus::NoReport ||
-            acked + loss + sacked == 0 {
-                // Do nothing
-            }
-        else {
+            self.delta_manager
+                .report_measurement(&mut self.rtt_win, 0, loss, now);
+        } else if report_status == ReportStatus::NoReport || acked + loss + sacked == 0 {
+            // Do nothing
+        } else {
             // Record RTT
             self.rtt_win.new_rtt_sample(min_rtt, now);
             if self.rtt_win.did_base_rtt_change() {
-                self.control_channel.update_field(&self.sc, &[("base_rtt", self.rtt_win.get_base_rtt())]);
+                self.control_channel
+                    .update_field(&self.sc, &[("base_rtt", self.rtt_win.get_base_rtt())])
+                    .unwrap();
             }
             // Update delta mode and delta
-              self.delta_manager.report_measurement(&mut self.rtt_win, acked, loss, now);
+            self.delta_manager
+                .report_measurement(&mut self.rtt_win, acked, loss, now);
 
             // Increase/decrease the cwnd corresponding to new measurements
             self.delay_control(min_rtt, acked, now);


### PR DESCRIPTION
Most of these changes are from rustfmt. Otherwise, this PR is a reorganization of existing logic to fit portus API version 0.4.

Due to the introduction of a helper macro in portus, I was able to remove most of the code in the binary source.